### PR TITLE
Set SDK version to 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,12 +2,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
If React Native project uses SDK version = 28. Build will not complete, because `react-native-simple-compass` has SDK version = 23